### PR TITLE
AP-5701: Sanitize params in the merchant demo app when doing offline ordering

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -54,7 +54,7 @@ end
 get '/corporate_account/:email' do
   content_type :json
   begin
-    corporate_account = Apruve::CorporateAccount.find(merchant_id, params['email'])
+    corporate_account = Apruve::CorporateAccount.find(merchant_id, Rack::Utils.escape_path(params['email']))
     puts "customer_id: #{corporate_account.customer_uuid}, id: #{corporate_account.id}"
     { customer_id: corporate_account.customer_uuid, corporate_account_id: corporate_account.id} .to_json
   rescue Apruve::NotFound


### PR DESCRIPTION
Using Rack escape_path utility to escape the email param when getting corporate accounts