### PR TITLE
AP-5989: Use new thread configuration in merchant demo

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -38,6 +38,10 @@ before '/webhook_notify' do
   @webhook_body = request.body.read
 end
 
+before do
+  Apruve.configure(ENV['APRUVE_API_KEY'], apruve_environment, config_overrides)
+end
+
 get '/offline_order' do
   erb :offline_orders
 end


### PR DESCRIPTION
The before do ensures that each time a request comes through the thread is configured properly.