### PR TITLE
AP-6243 Update to use corrected, v4-compliant apruve-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'activemodel'
 gem 'coffee-script'
 gem 'json', '>= 1.8.3'
 gem 'rack-flash3'
-gem 'apruve' #, :path => '../apruve-ruby'
+gem 'apruve'
 gem 'dotenv'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    apruve (2.0.0)
+    apruve (2.0.1)
       addressable (~> 2.3)
       faraday (>= 0.8.6, <= 0.9.0)
       faraday_middleware (~> 0.9)

--- a/app.rb
+++ b/app.rb
@@ -110,17 +110,17 @@ get '/' do
       sku:              'LTR-20R',
       price_ea_cents:   1200,
       quantity:         3,
-      amount_cents:     3600,
+      price_total_cents:     3600,
       view_product_url: 'https://merchant-demo.herokuapp.com'
   )
   @order.order_items << Apruve::OrderItem.new(
-      title:            'Legal Paper',
-      description:      '24 lb ream (250 Sheets). Paper dimensions are 8.5 x 14.00 inches.',
-      sku:              'LGL-24R',
-      price_ea_cents:   950,
-      quantity:         2,
-      amount_cents:     1900,
-      view_product_url: 'https://merchant-demo.herokuapp.com'
+      title:             'Legal Paper',
+      description:       '24 lb ream (250 Sheets). Paper dimensions are 8.5 x 14.00 inches.',
+      sku:               'LGL-24R',
+      price_ea_cents:    950,
+      quantity:          2,
+      price_total_cents: 1900,
+      view_product_url:  'https://merchant-demo.herokuapp.com'
   )
   erb :index
 end

--- a/public/css/merchant-demo.css
+++ b/public/css/merchant-demo.css
@@ -10,7 +10,7 @@ body {
   background-color:#ffffff;
   max-width:940px;
   min-height:100%;
-  width:100%;
+  width:100%!important;
 }
 
 .header {

--- a/public/css/merchant-demo.css
+++ b/public/css/merchant-demo.css
@@ -10,6 +10,7 @@ body {
   background-color:#ffffff;
   max-width:940px;
   min-height:100%;
+  width:100%;
 }
 
 .header {


### PR DESCRIPTION
Use the new [v2.0.1 apruve-ruby](https://github.com/apruve/apruve-ruby/releases/tag/v2.0.1) which adheres to the Apruve v4 documentation.

**Edit:** Now 100% more responsive!