### PR TITLE
AP-6886: Restrict to a corporate account id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,11 +34,12 @@ GEM
     json (1.8.3)
     minitest (5.9.0)
     multipart-post (2.0.0)
+    mustermann (1.0.2)
     public_suffix (3.0.0)
-    rack (1.6.4)
+    rack (2.0.4)
     rack-flash3 (1.0.5)
       rack
-    rack-protection (1.5.3)
+    rack-protection (2.0.1)
       rack
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -61,16 +62,17 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+    sinatra (2.0.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.1)
+      tilt (~> 2.0)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thread_safe (0.3.5)
-    tilt (2.0.5)
+    tilt (2.0.8)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -96,4 +98,4 @@ RUBY VERSION
    ruby 2.2.4p230
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/app.rb
+++ b/app.rb
@@ -49,7 +49,7 @@ get '/corporate_accounts' do
   begin
     corporate_accounts = Apruve::CorporateAccount.find_all(merchant_id)
     corporate_accounts = corporate_accounts.select { |ca| ca.id == apruve_corporate_account_id } if apruve_corporate_account_id
-    corporate_accounts
+    corporate_accounts.to_json
   rescue Apruve::NotFound
     status 404
     ''

--- a/app.rb
+++ b/app.rb
@@ -19,7 +19,7 @@ apruve_public_key = OpenSSL::PKey.read(File.new(('apruve.pub')))
 
 # default the environment to test.apruve.com
 apruve_environment = ENV['APRUVE_ENVIRONMENT'].nil? ? 'test' : ENV['APRUVE_ENVIRONMENT']
-
+apruve_corporate_account_id = ENV['APRUVE_CORPORATE_ACCOUNT_ID']
 
 # set the default credit application url
 ENV['APRUVE_CREDIT_APP_URL'] ||= 'http://localhost:3000/apply/munder-difflin-inc'
@@ -47,7 +47,9 @@ end
 
 get '/corporate_accounts' do
   begin
-    Apruve::CorporateAccount.find_all(merchant_id).to_json
+    corporate_accounts = Apruve::CorporateAccount.find_all(merchant_id)
+    corporate_accounts = corporate_accounts.select { |ca| ca.id == apruve_corporate_account_id } if apruve_corporate_account_id
+    corporate_accounts
   rescue Apruve::NotFound
     status 404
     ''


### PR DESCRIPTION
So that the customer list on offline demos is cleaner. Before we were pulling in every user that is part of a customer account with munder difflin. If the environment variable  is not there, it should revert to this previous behavior

I will add the Cogswell's Cogs id to the ENV after this is deployed.
